### PR TITLE
add: auth-source support for username and password

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -150,12 +150,32 @@ VALUE should be the referer."
           (request leetcode--url-login :sync t)
           (leetcode--csrf-token)))))
 
+(defun leetcode--credentials ()
+  (let* ((auth-source-creation-prompts
+          '((user  . "Leetcode user: ")
+            (secret . "Leetcode password for %u: ")))
+         (found (cl-first (auth-source-search :max 1
+                                              :host "leetcode.com"
+                                              :require '(:user :secret)
+                                              :create t))))
+    (when found
+      (eval `(ht ,@(--map `(,it ,(plist-get found it))
+                          '(:user :secret :save-function)))))))
+
+(defun leetcode--credentials-username (credentials)
+  (ht-get credentials :user))
+
+(defun leetcode--credentials-password (credentials)
+  (let ((secret (ht-get credentials :secret)))
+    (if (functionp secret) (funcall secret) secret)))
+
 (defun leetcode--login (account password)
   "Send login request and return a deferred object.
 When ACCOUNT or PASSWORD is empty string it will show a prompt."
   (when (or (string-empty-p account) (string-empty-p password))
-    (setq account (read-string "account: "))
-    (setq password (read-passwd "password: ")))
+    (let ((credentials (leetcode--credentials)))
+      (setq account (leetcode--credentials-username credentials))
+      (setq password (leetcode--credentials-password credentials))))
   (leetcode--loading-mode t)
   (request-deferred
    leetcode--url-login


### PR DESCRIPTION
Using Emacs' auth-source (e.g. .authinfo or .authinfo.gpg) for username and password. I think it is better than to leave it in the custom file.