### PR TITLE
testcase, answer, expeted answer, and stdout for wrong case

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -576,22 +576,27 @@ following possible value:
   (let-alist submission-detail
     (with-current-buffer (get-buffer-create leetcode--result-buffer-name)
       (erase-buffer)
-      (insert (format "Status: %s\n" .status_msg))
+      (insert (format "Status: %s" .status_msg))
       (cond
        ((eq .status_code 10)
-        (insert (format "%s/%s\n\n" .total_testcases .total_correct))
+        (insert (format " (%s/%s)\n\n" .total_correct .total_testcases))
         (insert (format "Runtime: %s, faster than %.2f%% of %s submissions.\n\n"
                         .status_runtime .runtime_percentile .pretty_lang))
         (insert (format "Memory Usage: %s, less than %.2f%% of %s submissions."
                         .status_memory .memory_percentile .pretty_lang)))
        ((eq .status_code 11)
-        (insert (format "%s/%s\n\n" .total_testcases .total_correct)))
-       ((eq .status_code 14) nil)
+        (insert (format " (%s/%s)\n\n" .total_correct .total_testcases))
+        (insert (format "Test Case: \n%s\n\n" .input))
+        (insert (format "Answer: %s\n\n" .code_output))
+        (insert (format "Expected Answer: %s\n\n" .expected_output))
+        (insert (format "Stdout: \n%s\n" .std_output)))
+       ((eq .status_code 14)
+        (insert "\n"))
        ((eq .status_code 15)
-        (insert "\n")
+        (insert "\n\n")
         (insert (format (alist-get 'full_runtime_error submission-detail))))
        ((eq .status_code 20)
-        (insert "\n")
+        (insert "\n\n")
         (insert (format (alist-get 'full_compile_error submission-detail)))))
       (display-buffer (current-buffer)
                       '((display-buffer-reuse-window


### PR DESCRIPTION
I add some useful message in the result buffer for the wrong case. The case in [#3 How about get the error info page if submit fail? Does it need lots of work?](https://github.com/kaiwk/leetcode.el/issues/3#issuecomment-483489208) seems solved now.
Also, I changed the "status \n total/passed" to "status (passed/total)".
Besides, I wonder if the testcase of the wrong can be copied to the -testcase buffer automatically?
Sorry for the inconvenience of this PR may bring to you, since I know little about lisp.
