### PR TITLE
Fix: Inconsistant problem-id

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -108,7 +108,7 @@ The object with following attributes:
 The elements of :problems has attributes:
 :status     String
 :id         Number
-:submit-id  Number
+:backend-id  Number
 :title      String
 :acceptance String
 :difficulty Number {1,2,3}
@@ -315,7 +315,7 @@ USER-AND-PROBLEMS is an alist comes from
                   (list
                    :status .status
                    :id .stat.frontend_question_id
-                   :submit-id .stat.question_id
+                   :backend-id .stat.question_id
                    :title .stat.question__title
                    :acceptance (format
                                 "%.1f%%"
@@ -334,7 +334,7 @@ USER-AND-PROBLEMS is an alist comes from
     (dovec (problem (plist-get leetcode--all-problems :problems))
       (dolist (topic (to-list .topics))
         (let-alist topic
-          (when (member (plist-get problem :submit-id) (to-list .questions))
+          (when (member (plist-get problem :backend-id) (to-list .questions))
             (let ((cur-tags (plist-get problem :tags)))
               (push .slug cur-tags)
               (plist-put problem :tags cur-tags))))))
@@ -651,7 +651,7 @@ LeetCode require slug-title as the request parameters."
                                      (leetcode--slugify-title
                                       (plist-get p :title))))
                             (plist-get leetcode--all-problems :problems)))
-         (problem-id (plist-get problem :submit-id)))
+         (problem-id (plist-get problem :backend-id)))
     (leetcode--debug "leetcode try slug-title: %s, problem-id: %s" slug-title problem-id)
     (let* ((url-request-method "POST")
            (url-request-extra-headers
@@ -855,7 +855,7 @@ following possible value:
                                                    (leetcode--slugify-title
                                                     (plist-get p :title))))
                                           (plist-get leetcode--all-problems :problems))
-                                :submit-id)))
+                                :backend-id)))
     (leetcode--debug "leetcode submit slug-title: %s, problem-id: %s" slug-title problem-id)
     (let* ((url-request-method "POST")
            (url-request-extra-headers


### PR DESCRIPTION
This pr addresses Issue #80.

## Reason and Facts

The reason causing the issue is that there are actually two kinds of id (can be found in the response of  this [API](https://leetcode.com/api/problems/all)) used by the official leetcode [website](https://leetcode.com/api/problems/all): 
- `frontend_question_id`: this is the one shown in column '#' on the [website](https://leetcode.com/api/problems/all) and the one for searching by. Users will only know and manipulate with this kind of id.
- `question_id`: this is the one that will be automatically specified in the request form for identifying the problem when you click the button `submit` or the button `run` on the website. Users will never know the existence of this kind of id.

In leetcode.el, the id-related fields of problem object are:
- `:id`: this exactly is `question_id`. This is not the one shown in column '#' and will only be used when sending api requests to leetcode's backend.
- `:pos`: this is the index of each problem in the response of API 'https://leetcode.com/api/problems/all'. This actually is the one shown in column '#', but totally different from `frontend_question_id`.

## Fixing

To keep consistent with the official website, I re-map the relationship as the table below:
| In leetcode.el  | On the [website](https://leetcode.com/api/problems/all) |
|---------------|--------------------------------------------------------|
| `:id`                 | `frontend_question_id` |
| `:backend-id` | `question_id`                 |

To be specific, I redefine the field `:id`, remove the field `:pos`, and introduce a new field `:backend-id`:
- `:id`: now this field is identical to `frontend_question_id` on the official website instead of `question_id`. What's important, **this id will be the one shown in the column '#' on the LC-problems page**. Similar to the website, users only need to know and manipulate with this id.
- `:pos`: now this has been removed
- `:backend-id`: this field is identical to `question_id`. Similar to the website, this will only be used when sending requests to the backend of leetcode, and users should never know about this id.

By the way, the problems list returned in the response of api 'https://leetcode.com/api/problems/all' is not sorted on `frontend_question_id` which corresponds to the field `:id`. To keep continuous on the field `:id` while avoiding costly sorting, I changed the data structure of `leetcode--all-problems.problems` from `list` to `vector`, so that we can just set the `.problems` at the index `frontend_question_id - 1` for each problem.

## Result after Fixing

After fixing this issue, the problem-id is now consistent with what shown on the official website, just as shown in the figure below:
![c](https://user-images.githubusercontent.com/24934207/104889831-b373fc00-59a9-11eb-975c-12233a105e2b.png)

And, the submission works correctly:
![image](https://user-images.githubusercontent.com/24934207/104900960-b83fac80-59b7-11eb-9b1e-51b15895fb04.png)

