### PR TITLE
Add variable to control tag display

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ LeetCode brings you offer, and now Emacs brings you LeetCode!
 | l      | change prefer language                 |
 | s      | filter problems by regex               |
 | t      | filter problems by tag                 |
+| T      | toggle tag display                     |
 | d      | filter problems by difficulty          |
 | /      | clear filters                          |
 | g      | refresh without fetching from LeetCode |
@@ -70,6 +71,9 @@ manually: `pip3 install my_cookies`.
 
 You can set your preferred LeetCode programming language and SQL by setting
 `leetcode-prefer-language` and `leetcode-prefer-sql`:
+
+If you prefer not to see problems' tags in the `*leetcode**`buffer by default.
+set `leetcode-prefer-tag-display` to nil
 
 ```elisp
 (setq leetcode-prefer-language "python3")

--- a/leetcode.el
+++ b/leetcode.el
@@ -1041,8 +1041,9 @@ Call `leetcode-solve-problem' on the current problem id."
            (get-buffer (leetcode--get-code-buffer-name title))))
         leetcode--problem-titles))
 
-(defvar leetcode-prefer-tag-display t
-  "Whether to display tags by default in the *leetcode* buffer.")
+(defcustom leetcode-prefer-tag-display t
+  "Whether to display tags by default in the *leetcode* buffer."
+  :type :boolean)
 
 (defvar leetcode--display-tags leetcode-prefer-tag-display
   "(Internal) Whether tags are displayed the *leetcode* buffer.")


### PR DESCRIPTION
I didn't that problems' tags were displayed in `*leetcode*`: it feels like a spoiler for the problem. So I added the ability to disable their display by default along with a display toggle.

There's also a line of indentation changes that snuck in, but seeing as it's one line I think it's fine