### PR TITLE
fix: use conventional lighter format for leetcode-solution-mode

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -1404,7 +1404,7 @@ It will restore the layout based on current buffer's name."
 (define-minor-mode leetcode-solution-mode
   "Minor mode to provide shortcut and hooks."
   :require 'leetcode
-  :lighter "LC Solution"
+  :lighter " LC-Solution"
   :group 'leetcode
   :keymap leetcode-solution-mode-map)
 


### PR DESCRIPTION
I noticed problems with spaces in the `lighter` for `leetcode-solution-mode` when using powerline to format the modeline.
It splits the minor mode component of the mode-line by spaces which breaks the keymapping on mouse click.  I cant find any documentation that explicitly warns against using spaces in minor mode lighters (although easy-mmode.el does mention the common practice of starting the lighter with a preceding space), but it seems to just be a widely adopted convention that other packages, like powerline, rely on.