### PR TITLE
Add `leetcode-ignore-region` to ignore lines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ You can save solution by setting `leetcode-save-solutions`:
 (setq leetcode-directory "~/leetcode")
 ```
 
+If you want to have some code before your solution, which may make auto-completion work better but shouldn't been submitted, you can customize `leetcode-ignore-region` to ignore lines in your code. For example, suppose you have a `common.h` and some custom definations, and `leetcode-ignore-region` is set to `'("" "// start code")`, only code below `// start code` will be submitted:
+
+```c++
+#include "common.h"
+... your custom definations ...
+// start code
+
+class Solution {
+    ......
+```
+
 # Work with Org Mode
 
 `leetcode-show-problem-by-slug` will let you put to org files with a link in this format to show the question after the *leetcode* buffer is load like [elisp:(leetcode-show-problem-by-slug (leetcode--slugify-title "ZigZag Conversion"))]

--- a/leetcode.el
+++ b/leetcode.el
@@ -98,7 +98,7 @@
 (defcustom leetcode-prefer-language "python3"
   "LeetCode programming language.
 c, cpp, csharp, golang, java, javascript, typescript, kotlin, php, python,
-python3, ruby, rust, scala, swift."
+python3, racket, ruby, rust, scala, swift."
   :group 'leetcode
   :type 'string)
 
@@ -202,7 +202,7 @@ Default is programming language.")
     ("mysql" . ".sql") ("mssql" . ".sql") ("oraclesql" . ".sql"))
   "LeetCode programming language suffixes.
 c, cpp, csharp, golang, java, javascript, typescript, kotlin, php, python,
-python3, ruby, rust, scala, swift, mysql, mssql, oraclesql.")
+python3, racket, ruby, rust, scala, swift, mysql, mssql, oraclesql.")
 
 (defvar leetcode--filter-regex nil "Filter rows by regex.")
 (defvar leetcode--filter-tag nil "Filter rows by tag.")


### PR DESCRIPTION
Sometimes we may want to write some custom code, maybe for better code-completion support, which should be ignored during submissions. `leetcode-ignore-region` introduces 2 string variables which marks the begin/end of that region.