### PR TITLE
Fixes for leetcode-quit and leetcode--kill-buff-and-delete-window

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -1169,8 +1169,9 @@ Call `leetcode-solve-problem' on the current problem id."
 
 (defun leetcode--kill-buff-and-delete-window (buf)
   "Kill BUF and delete its window."
-  (delete-windows-on buf t)
-  (kill-buffer buf))
+  (when buf
+    (delete-windows-on buf t)
+    (kill-buffer buf)))
 
 (defun leetcode-quit ()
   "Close and delete leetcode related buffers and windows."
@@ -1185,7 +1186,8 @@ Call `leetcode-solve-problem' on the current problem id."
             (leetcode--kill-buff-and-delete-window (get-buffer (leetcode--detail-buffer-name problem-id)))
             (leetcode--kill-buff-and-delete-window (get-buffer (leetcode--result-buffer-name problem-id)))
             (leetcode--kill-buff-and-delete-window (get-buffer (leetcode--testcase-buffer-name problem-id)))))
-        leetcode--problem-titles))
+        leetcode--problem-titles)
+  (setq leetcode--problem-titles '()))
 
 (defun leetcode--set-lang (snippets)
   "Set `leetcode--lang' based on langSlug in SNIPPETS."


### PR DESCRIPTION
Ensure that leetcode-quit can be run multiple times in the same emacs session without killing random buffers unrelated to leetcode.

Steps to reproduce:

* `M-x leetcode`
* select some problem from the problem list a click on "Solve it" link
* `M-x leetcode-quit`
* [optional] `M-x leetcode`
* [optional] select a *different* problem from the problem list a click on "Solve it" link
* `M-x leetcode-quit`
* observe some non-leetcode buffer is killed (possibly the `*scratch*` buffer if no other buffers were open)