### PR TITLE
Remove dash as a dependency

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -5,7 +5,7 @@
 ;; Author: Wang Kai <kaiwkx@gmail.com>
 ;; Keywords: extensions, tools
 ;; URL: https://github.com/kaiwk/leetcode.el
-;; Package-Requires: ((emacs "26.1") (s "1.13.0") (dash "2.16.0") (aio "1.0") (log4e "0.3.3"))
+;; Package-Requires: ((emacs "26.1") (s "1.13.0") (aio "1.0") (log4e "0.3.3"))
 ;; Version: 0.1.27
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -43,7 +43,6 @@
 (require 'mm-url)
 (require 'cl-lib)
 
-(require 'dash)
 (require 's)
 (require 'aio)
 (require 'log4e)


### PR DESCRIPTION
## Problem

In commit
https://github.com/kaiwk/leetcode.el/commit/300d57a4956243ee602876e9b26694a5a651af55
dash was removed as a dependency but it is still declared as one. This
is confusing and makes it easy to accidental revert that work.


## Solution

Remove it as a declared dependency

## Testing

I checked for any instance of the string `(-` which would indicate the
use of the `dash` library and found none.