### PR TITLE
Allow my_cookies to be installed in an isolated python virtual-environment

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -5,7 +5,7 @@
 ;; Author: Wang Kai <kaiwkx@gmail.com>
 ;; Keywords: extensions, tools
 ;; URL: https://github.com/kaiwk/leetcode.el
-;; Package-Requires: ((emacs "26.1") (s "1.13.0") (aio "1.0") (log4e "0.3.3"))
+;; Package-Requires: ((emacs "28.1") (s "1.13.0") (aio "1.0") (log4e "0.3.3"))
 ;; Version: 0.1.27
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -73,12 +73,17 @@
   "Install leetcode dependencies."
   (let ((async-shell-command-display-buffer t))
     (async-shell-command
-     "pip3 install my_cookies"
+     (format "python -m venv --clear %s && %s/bin/pip3 install my_cookies" leetcode-python-environment leetcode-python-environment)
      (get-buffer-create "*leetcode-install*"))))
+
+(defun leetcode--my-cookies-path ()
+  "Find the path to the my_cookies executable."
+  (or (executable-find (format "%s/bin/my_cookies" leetcode-python-environment))
+      (executable-find "my_cookies")))
 
 (defun leetcode--check-deps ()
   "Check if all dependencies installed."
-  (if (executable-find "my_cookies")
+  (if (leetcode--my-cookies-path)
       t
     (leetcode--install-my-cookie)
     nil))
@@ -120,6 +125,11 @@ mysql, mssql, oraclesql."
   "When execute `leetcode', always delete other windows."
   :group 'leetcode
   :type 'boolean)
+
+(defcustom leetcode-python-environment (file-name-concat user-emacs-directory "leetcode-env")
+  "The path to the isolated python virtual-environment to use."
+  :group 'leetcode
+  :type 'directory)
 
 (cl-defstruct leetcode-user
   "A LeetCode User.
@@ -377,8 +387,8 @@ VALUE should be the referer."
 
 (defun leetcode--cookie-get-all ()
   "Get leetcode session with `my_cookies'. You can install it with pip."
-  (let* ((my-cookies (executable-find "my_cookies"))
-         (my-cookies-output (shell-command-to-string "my_cookies"))
+  (let* ((my-cookies (leetcode--my-cookies-path))
+         (my-cookies-output (shell-command-to-string (leetcode--my-cookies-path)))
          (cookies-list (seq-filter (lambda (s) (not (string-empty-p s)))
                                    (s-split "\n" my-cookies-output 'OMIT-NULLS)))
          (cookies-pairs (seq-map (lambda (s) (s-split-up-to " " s 1 'OMIT-NULLS)) cookies-list)))


### PR DESCRIPTION
## Problem

I am unable to run `leetcode` because of how this package tries to
install the `my_cookie` Python dependency.

## Evaluation

On some systems a user may not want or may not be able to install a
Python package globally.

## Solution

The Python community has developed a way of isolating installation
requirements through something called a virtual-environment. This pull
request uses this technology to install `my_cookies` in an isolated
environment that leetcode can manage entirely on its own.

In this PR I generate a new virtual-environment and install
`my_cookie` in there.

Note: In this PR I make use of `file-name-concat` which was added in
Emacs `28.1`, released over 6 years ago. This function is also
available through the excellent `compat` package, which I would be
willing to add a dependency if we are not okay with dropping support
for these old versions of Emacs.

## Testing

After this small change I was able to run `leetcode`.