### PR TITLE
Don't override internal shr-current-font variable

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -1097,7 +1097,6 @@ will show the detail in other window and jump to it."
                       "dislikes: " (number-to-string dislikes)))
       ;; Sometimes LeetCode don't have a '<p>' at the outermost...
       (insert "<p>" content "</p>")
-      (setq shr-current-font t)
       (leetcode--replace-in-buffer "" "")
       ;; NOTE: shr.el can't render "https://xxxx.png", so we use "http"
       (leetcode--replace-in-buffer "https" "http")


### PR DESCRIPTION
## Problem

When viewing a problem's details the `*Messages*` buffer gets filled
with messages like `Invalid face reference: t [598 times]`. This is
annoying but does not cause any failures.

## Solution

After poking around a little bit I removed this line and noticed that
the messages went away and the buffer was displayed as expected.

## Testing

I've reloaded various descriptions and checked that they display
sensibly and that the error message no longer appears in the
`*Messages*` buffer.