### PR TITLE
Fix leetcode-daily question id type

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -889,7 +889,7 @@ row."
       (goto-char url-http-end-of-headers)
       (let-alist (json-read)
         (let ((qid .data.activeDailyCodingChallengeQuestion.question.qid))
-          (leetcode-show-problem (string-to-number qid)))))))
+          (leetcode-show-problem qid))))))
 
 (aio-defun leetcode-try ()
   "Asynchronously test the code using customized testcase."


### PR DESCRIPTION
In #129, the `problem-id` argument of `leetcode-show-problem` was updated to be a string, but `leetcode-daily` still has a call to `string-to-number` which causes the daily problem not to show (since the equality match in `leetcode--get-problem-by-id` never triggers due to the type mismatch). Removing the type conversion fixes the issue and allows the daily problem to be shown.