### PR TITLE
Fix `leetcode-show-problem` outside of the problems table

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -1128,7 +1128,8 @@ Get problem by id and use `shr-render-buffer' to render problem
 detail. This action will show the detail in other window and jump
 to it."
   (interactive (list (read-string "Show problem by problem id: "
-                                  (leetcode--get-current-problem-id))))
+                                  (when (derived-mode-p 'leetcode--problems-mode)
+                                    (leetcode--get-current-problem-id)))))
   (let* ((problem (leetcode--get-problem-by-id problem-id))
          (title-slug (leetcode-problem-title-slug problem))
          (problem-with-title (aio-await (leetcode--ensure-question-title problem)))


### PR DESCRIPTION
This fixes the following error when trying to call `leetcode-show-problem` interactively outside of the problems buffer:
```
leetcode--get-current-problem-id: Wrong type argument: arrayp, nil
```

This is due to trying to access a tabulated list element outside of tabulated-list-mode. Adding a check to make sure the current buffer is a problems buffer before calling `leetcode--get-current-problem-id` for the interactive default.