### PR TITLE
Add reporting for Memory Limit Exceeded errors (status 12)

### DIFF
--- a/leetcode.el
+++ b/leetcode.el
@@ -1080,6 +1080,7 @@ STATUS_CODE has following possible value:
 
 - 10: Accepted
 - 11: Wrong Anwser
+- 12: Memory Limit Exceeded
 - 14: Time Limit Exceeded
 - 15: Runtime Error.  full_runtime_error
 - 20: Compile Error.  full_compile_error"
@@ -1107,6 +1108,10 @@ STATUS_CODE has following possible value:
         (insert (format "Expected Answer: %s\n\n" .expected_output))
         (unless (string-empty-p .std_output)
           (insert (format "Stdout: \n%s\n" .std_output))))
+       ((eq .status_code 12)
+        (insert (format "Status: %s" (leetcode--add-font-lock .status_msg 'leetcode-error-face)))
+        (insert (format "\n\n%s / %s testcases passed\n" .total_correct .total_testcases))
+        (insert (format "Last Test Case: %s\n" .last_testcase)))
        ((eq .status_code 14)
         (insert (format "Status: %s" (leetcode--add-font-lock .status_msg 'leetcode-error-face)))
         (insert (format "\n\n%s / %s testcases passed\n" .total_correct .total_testcases))


### PR DESCRIPTION
For `leetcode--show-submission-result` we're not showing status if there's a Memory Limit Exceeded error (status 12).  This can happen, for example, if a submission in Python hits the Python recursion depth limit.  When it happens, nothing is displayed in the submission result buffer at all.

In this change, we add some handling to deal with this error for the submission results.