### PR TITLE
Pandas feature for database problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ You can save solution by setting `leetcode-save-solutions`:
 (setq leetcode-directory "~/leetcode")
 ```
 
+### Pandas Mode for Database Problems
+If a LeetCode problem provides SQL snippets, `leetcode.el` can now use Pandas
+as the prefered language:
+```elisp
+(setq leetcode-prefer-sql "pythondata")
+```
+
+
 # Work with Org Mode
 
 `leetcode-show-problem-by-slug` will let you put to org files with a link in this format to show the question after the *leetcode* buffer is load like [elisp:(leetcode-show-problem-by-slug (leetcode--slugify-title "ZigZag Conversion"))]

--- a/leetcode.el
+++ b/leetcode.el
@@ -114,7 +114,7 @@ python3, ruby, rust, scala, swift."
 
 (defcustom leetcode-prefer-sql "mysql"
   "LeetCode sql implementation.
-mysql, mssql, oraclesql."
+mysql, mssql, oraclesql, pythondata."
   :group 'leetcode
   :type 'string)
 
@@ -227,7 +227,7 @@ Default is programming language.")
     ("kotlin" . ".kt") ("php" . ".php") ("python" . ".py") ("python3" . ".py")
     ("racket" . ".rkt") ("ruby" . ".rb") ("rust" . ".rs")
     ("scala" . ".scala") ("swift" . ".swift") ("typescript" . ".ts")
-    ("mysql" . ".sql") ("mssql" . ".sql") ("oraclesql" . ".sql"))
+    ("mysql" . ".sql") ("mssql" . ".sql") ("oraclesql" . ".sql") ("pythondata" . ".py"))
   "A map of language slug name to LeetCode programming language suffix.
 c, cpp, csharp, golang, java, javascript, typescript, kotlin, php, python,
 python3, ruby, rust, scala, swift, mysql, mssql, oraclesql.")

--- a/leetcode.el
+++ b/leetcode.el
@@ -113,7 +113,8 @@ python3, ruby, rust, scala, swift."
   :type 'string)
 
 (defcustom leetcode-prefer-sql "mysql"
-  "LeetCode sql implementation.
+  "LeetCode SQL or Pandas implementation.
+Possible values:
 mysql, mssql, oraclesql, pythondata."
   :group 'leetcode
   :type 'string)


### PR DESCRIPTION
**Summary**

This PR adds automatic Pandas support for LeetCode database (SQL) problems.
When the problem contains MySQL/MSSQL/OracleSQL snippets, leetcode.el can
now open the problem in pandas if the user selects "pythondata" as their preferred
sql language.  This is in keeping with the options available on the leetcode website.

**Implementation**

- updated `leetcode--prefer-sql` to include `pythondata`
- updated `leetcode--lang-suffixes` to include `("pythondata" . ".py")`
- Preserves existing SQL functionality

**Testing**

Verified locally on multiple database problems (Triangle Judgment, and Combine Two Tables)
using Emacs 30.2


Resolves #152 