### PR TITLE
Add optional Firefox-family cookie source (Zen support)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-09-07  kazure
+
+	* leetcode.el (leetcode-cookie-firefox-profile-dir)
+	(leetcode--firefox-cookie-script, leetcode--cookies-from-output)
+	(leetcode--read-firefox-cookies, leetcode--my-cookies-cookies)
+	(leetcode--cookie-get-all): add optional Firefox-family cookie
+	source, reading cookies.sqlite directly (Zen support) before
+	falling back to my_cookies.
+
 2022-05-03  Wang Kai  <kaiwkx@gmail.com>
 
 	* leetcode.el (leetcode--set-evil-local-map): set evil-normal-state-local-map.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ You can save solution by setting `leetcode-save-solutions`:
 (setq leetcode-directory "~/leetcode")
 ```
 
+## Cookie source
+
+By default, the LeetCode session is restored with `my_cookies` (see
+Installation).  If you log in with a Firefox-family browser that
+`my_cookies` does not know — for example [Zen](https://zen-browser.app/),
+whose profiles live under `~/.config/zen` — set
+`leetcode-cookie-firefox-profile-dir` and cookies are read directly from
+its `cookies.sqlite` instead:
+
+```elisp
+(setq leetcode-cookie-firefox-profile-dir "~/.config/zen")
+```
+
+The value must be the directory containing the profile subdirectories
+(`~/.mozilla/firefox` for Firefox).  When the directory is absent or has
+no cookie for LeetCode, `my_cookies` is used as a fallback.
+
 # Work with Org Mode
 
 `leetcode-show-problem-by-slug` will let you put to org files with a link in this format to show the question after the *leetcode* buffer is load like [elisp:(leetcode-show-problem-by-slug (leetcode--slugify-title "ZigZag Conversion"))]

--- a/leetcode.el
+++ b/leetcode.el
@@ -138,6 +138,24 @@ mysql, mssql, oraclesql."
   :group 'leetcode
   :type 'directory)
 
+(defcustom leetcode-cookie-firefox-profile-dir nil
+  "Directory of a Firefox-family browser profile to read cookies from.
+
+LeetCode cookies are normally read with `my_cookies' (see
+`leetcode--cookie-get-all'), which does not know the Zen browser
+and always returns the first browser jar it finds, even when the
+session in it is stale.  When this is non-nil, cookies are read
+directly from the cookies.sqlite of the given Firefox-family
+profile directory (Zen, LibreWolf, Waterfox, Firefox) and used
+instead.  The value must be the directory that contains the
+profile subdirectories, e.g. \"~/.config/zen\" for Zen or
+\"~/.mozilla/firefox\" for Firefox.
+
+When the directory is absent or contains no cookie for the
+LeetCode domain, `my_cookies' is used as a fallback."
+  :group 'leetcode
+  :type '(choice (const :tag "Disabled" nil) directory))
+
 (cl-defstruct leetcode-user
   "A LeetCode User.
 The object with following attributes:
@@ -419,14 +437,121 @@ query consolePanelConfig($titleSlug: String!) {
 VALUE should be the referer."
   (cons "Referer" value))
 
+(defconst leetcode--firefox-cookie-script
+  "import argparse
+import configparser
+import glob
+import os
+import sqlite3
+
+def cookie_files(profile_dir):
+    files = sorted(glob.glob(os.path.join(profile_dir, '**', 'cookies.sqlite'),
+                             recursive=True))
+    if not files:
+        return files
+    ini = os.path.join(profile_dir, 'profiles.ini')
+    default = None
+    if os.path.isfile(ini):
+        try:
+            cp = configparser.ConfigParser()
+            cp.read(ini, encoding='utf8')
+            # Mirror browser_cookie3 semantics: an Install section's
+            # Default wins over Default=1 sections.
+            for section in cp.sections():
+                if section.startswith('Install'):
+                    default = cp[section].get('Default')
+                    break
+                if cp[section].get('Default') == '1' and not default:
+                    default = cp[section].get('Path')
+        except Exception:
+            default = None
+    if default:
+        target = os.path.join(profile_dir, default, 'cookies.sqlite')
+        if target in files:
+            files.remove(target)
+        files.insert(0, target)
+    return files
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--profile-dir', required=True)
+    parser.add_argument('--domain', required=True)
+    args = parser.parse_args()
+    profile_dir = os.path.expanduser(args.profile_dir)
+    for path in cookie_files(profile_dir):
+        if not os.path.isfile(path):
+            continue
+        try:
+            # immutable=1: read-only view that bypasses the lock the
+            # browser holds on cookies.sqlite while running.
+            db = sqlite3.connect('file:%s?immutable=1' % path, uri=True)
+            try:
+                rows = db.execute('select name, value from moz_cookies '
+                                  'where host like ?',
+                                  ('%' + args.domain + '%',)).fetchall()
+            finally:
+                db.close()
+        except sqlite3.Error:
+            continue
+        if rows:
+            seen = {}
+            for name, value in rows:
+                seen[name] = value
+            for name in sorted(seen):
+                print(name, seen[name])
+            return
+
+if __name__ == '__main__':
+    main()
+"
+  "Python script that reads cookies from a Firefox-family cookies.sqlite.
+Prints one `name value' line per cookie for the requested domain.
+Exits silently (empty output, status 0) when the profile directory
+is absent or has no cookie for the domain.")
+
+(defun leetcode--cookies-from-output (output)
+  "Parse OUTPUT lines of \"name value\" into a list of (NAME VALUE) pairs."
+  (let ((cookies-list (seq-filter (lambda (s) (not (string-empty-p s)))
+                                  (s-split "\n" output 'OMIT-NULLS))))
+    (seq-map (lambda (s) (s-split-up-to " " s 1 'OMIT-NULLS)) cookies-list)))
+
+(defun leetcode--read-firefox-cookies (dir)
+  "Read LeetCode cookies from Firefox-family profile directory DIR.
+Return a list of (NAME VALUE) pairs, or nil when DIR is absent or
+has no cookie for `leetcode--domain'."
+  (when (file-directory-p (expand-file-name dir))
+    (let ((python (or (executable-find "python3")
+                      (executable-find "python"))))
+      (when python
+        (with-temp-buffer
+          (insert leetcode--firefox-cookie-script)
+          (let* ((out (generate-new-buffer " *leetcode-cookie-output*"))
+                (status
+                 (call-process-region (point-min) (point-max) python
+                                      nil out nil
+                                      "-" "--profile-dir"
+                                      (expand-file-name dir)
+                                      "--domain" leetcode--domain)))
+            (unwind-protect
+                (and (eq status 0)
+                     (leetcode--cookies-from-output
+                      (with-current-buffer out (buffer-string))))
+              (kill-buffer out))))))))
+
+(defun leetcode--my-cookies-cookies ()
+  "Get LeetCode cookies with `my_cookies'. You can install it with pip."
+  (leetcode--cookies-from-output
+   (shell-command-to-string (leetcode--my-cookies-path))))
+
 (defun leetcode--cookie-get-all ()
-  "Get leetcode session with `my_cookies'. You can install it with pip."
-  (let* ((my-cookies (leetcode--my-cookies-path))
-         (my-cookies-output (shell-command-to-string (leetcode--my-cookies-path)))
-         (cookies-list (seq-filter (lambda (s) (not (string-empty-p s)))
-                                   (s-split "\n" my-cookies-output 'OMIT-NULLS)))
-         (cookies-pairs (seq-map (lambda (s) (s-split-up-to " " s 1 'OMIT-NULLS)) cookies-list)))
-    cookies-pairs))
+  "Get LeetCode cookies.
+
+Read them from `leetcode-cookie-firefox-profile-dir' when it is
+set, falling back to `my_cookies'."
+  (or (and leetcode-cookie-firefox-profile-dir
+           (leetcode--read-firefox-cookies
+            leetcode-cookie-firefox-profile-dir))
+      (leetcode--my-cookies-cookies)))
 
 (defun leetcode--cookie-get (cookie-key)
   "Get LeetCode cookie value by COOKIE-KEY."
@@ -1206,7 +1331,8 @@ will show the detail in other window and jump to it."
                       "dislikes: " (number-to-string dislikes)))
       ;; Sometimes LeetCode don't have a '<p>' at the outermost...
       (insert "<p>" content "</p>")
-      (leetcode--replace-in-buffer "" "")
+      (leetcode--replace-in-buffer "
+" "")
       ;; NOTE: shr.el can't render "https://xxxx.png", so we use "http"
       (leetcode--replace-in-buffer "https" "http")
       (shr-render-buffer (current-buffer)))
@@ -1429,7 +1555,8 @@ major mode by `leetcode-prefer-language'and `auto-mode-alist'."
             (leetcode--insert-code-start-marker)
             (insert template-code)
             (leetcode--insert-code-end-marker)
-            (leetcode--replace-in-buffer "" "")))
+            (leetcode--replace-in-buffer "
+" "")))
         (funcall (assoc-default suffix auto-mode-alist #'string-match-p))
         (leetcode-solution-mode t))
 

--- a/leetcode.el
+++ b/leetcode.el
@@ -32,6 +32,11 @@
 ;;
 ;; Since most HTTP requests works asynchronously, it won't block Emacs.
 ;;
+;; LeetCode cookies are restored from local browser cookies, by
+;; default with `my_cookies'.  `leetcode-cookie-firefox-profile-dir'
+;; can be set to read them directly from a Firefox-family profile
+;; directory (e.g. Zen).
+;;
 ;;; Code:
 (eval-when-compile
   (require 'let-alist))

--- a/test/leetcode-tests.el
+++ b/test/leetcode-tests.el
@@ -75,5 +75,33 @@
     (should (equal (leetcode--get-code-buffer-name "Reverse Nodes in k-Group")
                    "reverse-nodes-in-k-group.py"))))
 
+(ert-deftest leetcode-cookie-test-parse-output ()
+  (should (equal (leetcode--cookies-from-output "a 1\nb 2 3\n")
+                 '(("a" "1") ("b" "2 3"))))
+  (should (equal (leetcode--cookies-from-output "") nil))
+  (should (equal (leetcode--cookies-from-output "no-space-here\n")
+                 '(("no-space-here")))))
+
+(ert-deftest leetcode-cookie-test-read-firefox-dir-absent ()
+  (should (equal (leetcode--read-firefox-cookies "/nonexistent/xyz") nil)))
+
+(ert-deftest leetcode-cookie-test-get-all-fallback ()
+  (cl-letf (((symbol-function 'leetcode--read-firefox-cookies)
+             (lambda (_) nil))
+            ((symbol-function 'leetcode--my-cookies-cookies)
+             (lambda () '(("a" "1") ("b" "2")))))
+    (let ((leetcode-cookie-firefox-profile-dir "/some/dir"))
+      (should (equal (leetcode--cookie-get-all)
+                     '(("a" "1") ("b" "2")))))))
+
+(ert-deftest leetcode-cookie-test-get-all-firefox-first ()
+  (cl-letf (((symbol-function 'leetcode--read-firefox-cookies)
+             (lambda (_) '(("LEETCODE_SESSION" "x"))))
+            ((symbol-function 'leetcode--my-cookies-cookies)
+             (lambda () (error "should not be called"))))
+    (let ((leetcode-cookie-firefox-profile-dir "/some/dir"))
+      (should (equal (leetcode--cookie-get-all)
+                     '(("LEETCODE_SESSION" "x")))))))
+
 (provide 'leetcode-tests)
 ;;; leetcode-tests.el ends here


### PR DESCRIPTION
## Problem

LeetCode cookies are restored with `my_cookies`, which is built on `browser_cookie3`. That library:

- does not know the **Zen browser** (Zen profiles live under `~/.config/zen`, not `~/.mozilla/firefox`), and
- always returns the first browser jar it finds, even when the session in it is stale or invalid.

So when the user is logged into LeetCode via Zen (or another browser `my_cookies` mishandles), fetching the problem list works (no login required), but `leetcode-try` / `leetcode-submit` fail.

## Solution

Add a `leetcode-cookie-firefox-profile-dir` defcustom. When non-nil, cookies are read **directly from `cookies.sqlite`** of the given Firefox-family profile directory (Zen, LibreWolf, Waterfox, Firefox) via an embedded Python 3 script (standard library only):

```elisp
(setq leetcode-cookie-firefox-profile-dir "~/.config/zen")
```

- The script locates the default profile via `profiles.ini` (Install section wins, mirroring `browser_cookie3` semantics) with a glob fallback.
- `cookies.sqlite` is opened with `sqlite3`'s `immutable=1` read-only mode, which bypasses the lock the browser holds on the database while running. (This is why the Python script is needed: Emacs' built-in sqlite module cannot open it in immutable mode.)
- Python is already a dependency of this package (`my_cookies`), and the executable is resolved the same way `leetcode--install-my-cookie` does (`python3` then `python`).
- When the directory is absent or has no cookie for the LeetCode domain, `my_cookies` is used as a fallback.
- **Default is nil, so existing behavior is unchanged.**

## Tests

Added 4 pure unit tests in `test/leetcode-tests.el` (no network/browser needed), runnable with the selector `"leetcode-cookie"`:

```sh
cask exec emacs -Q --batch -L . -L test -l leetcode-tests.el \
  --eval '(ert-run-tests-batch-and-exit "leetcode-cookie")'
```

Verified against a real Zen profile (`~/.config/zen`): 16 cookies read, including `LEETCODE_SESSION` and `csrftoken`.
